### PR TITLE
Fix package name to match repo name and README

### DIFF
--- a/adb.go
+++ b/adb.go
@@ -2,7 +2,7 @@ package main
 
 import (
     "fmt"
-    "cloud_adb_client/webserver"
+    "cloud_client/webserver"
     "gopkg.in/gcfg.v1"
     "flag"
 )


### PR DESCRIPTION
No need to rename into `cloud_adb_client` anymore
